### PR TITLE
Fix cross-compilation linker issue

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"

--- a/core/src/plugin_host.rs
+++ b/core/src/plugin_host.rs
@@ -105,7 +105,6 @@ impl PluginHandle {
 /// Manager responsible for discovering and running plugins.
 pub struct PluginManager {
     workspace_root: PathBuf,
-    plugins_dir: PathBuf,
     pub plugins: HashMap<String, PluginHandle>,
 }
 
@@ -128,7 +127,7 @@ impl PluginManager {
                 }
             }
         }
-        Ok(Self { workspace_root, plugins_dir, plugins })
+        Ok(Self { workspace_root, plugins })
     }
 
     /// List current plugins and their status.


### PR DESCRIPTION
## Summary
- configure aarch64 builds to use the `aarch64-linux-gnu-gcc` linker
- drop unused `plugins_dir` field from `PluginManager`

## Testing
- `cargo build`
- `cargo build --target=aarch64-unknown-linux-gnu --release`


------
https://chatgpt.com/codex/tasks/task_e_689a591c63b48332804ee637a18bfa50