### PR TITLE
Ensure family chat web UI builds with modern Node

### DIFF
--- a/plugins/family_chat/README.md
+++ b/plugins/family_chat/README.md
@@ -7,7 +7,7 @@ assets under `webui/dist` which are embedded at build time.
 ## Building
 
 Before compiling the plugin you need the web UI assets under `webui/dist`.
-Generate them with:
+Ensure you are using Node.js 18 or newer. Generate the assets with:
 
 ```
 cd plugins/family_chat/webui

--- a/plugins/family_chat/tests/webui_build.rs
+++ b/plugins/family_chat/tests/webui_build.rs
@@ -24,4 +24,3 @@ fn webui_assets_build() {
 
     assert!(out_dir.join("index.html").exists(), "no build output");
 }
-

--- a/plugins/family_chat/tests/webui_build.rs
+++ b/plugins/family_chat/tests/webui_build.rs
@@ -1,0 +1,27 @@
+use std::process::Command;
+
+#[test]
+fn webui_assets_build() {
+    let webui_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/webui");
+
+    // Install dependencies
+    let status = Command::new("npm")
+        .args(["ci"])
+        .current_dir(webui_dir)
+        .status()
+        .expect("failed to run npm ci");
+    assert!(status.success(), "npm ci failed");
+
+    // Build into a temporary directory so the repository files are untouched
+    let tmp = tempfile::tempdir().unwrap();
+    let out_dir = tmp.path();
+    let status = Command::new("npm")
+        .args(["run", "build", "--", "--outDir", out_dir.to_str().unwrap()])
+        .current_dir(webui_dir)
+        .status()
+        .expect("failed to run npm build");
+    assert!(status.success(), "npm build failed");
+
+    assert!(out_dir.join("index.html").exists(), "no build output");
+}
+

--- a/plugins/family_chat/webui/package.json
+++ b/plugins/family_chat/webui/package.json
@@ -2,6 +2,9 @@
   "name": "family-chat-webui",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=18"
+  },
   "scripts": {
     "dev": "vite",
     "build": "vite build",


### PR DESCRIPTION
## Summary
- require Node.js 18+ for the family chat web UI
- document Node requirement in README
- add integration test that installs deps and builds web UI into a temp directory

## Testing
- `npm --prefix plugins/family_chat/webui test`
- `cargo test -p family_chat`


------
https://chatgpt.com/codex/tasks/task_e_689c7df99e208332b90ccd86ad11f354