### PR TITLE
feat: add admin user management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,6 +490,7 @@ dependencies = [
  "tower",
  "tracing",
  "tracing-subscriber",
+ "url",
  "uuid",
  "walkdir",
 ]

--- a/plugins/family_chat/Cargo.toml
+++ b/plugins/family_chat/Cargo.toml
@@ -36,6 +36,7 @@ walkdir = "2"
 plugin_api = { path = "../../plugin_api" }
 rust-embed = "8"
 futures = "0.3"
+url = "2"
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
## Summary
- extend auth model with display name, avatar, disabled state, and unique usernames
- implement admin-only routes for listing, creating, and updating users
- block disabled users from authenticating and add thorough tests

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689c92d98150833296cfcb7eeafb47c7