### PR TITLE
feat: add realtime presence typing and unread counters

### DIFF
--- a/plugins/family_chat/src/api.rs
+++ b/plugins/family_chat/src/api.rs
@@ -1,4 +1,6 @@
-use crate::{auth, config::Config, db, embed::ui_router, files, messages, rooms};
+use crate::{
+    auth, config::Config, db, embed::ui_router, files, messages, presence, reads, rooms, typing,
+};
 use anyhow::Result;
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::{
@@ -47,6 +49,8 @@ pub struct AppState {
     pub auth_file: PathBuf,
     pub login_limiter: auth::LoginRateLimiter,
     pub ws_members: std::sync::Arc<Mutex<HashMap<Uuid, HashSet<u32>>>>,
+    pub presence: std::sync::Arc<presence::Presence>,
+    pub typing: std::sync::Arc<typing::TypingTracker>,
 }
 
 impl AppState {
@@ -76,6 +80,12 @@ impl AppState {
             auth_file,
             login_limiter: auth::LoginRateLimiter::new(5, std::time::Duration::from_secs(60)),
             ws_members: std::sync::Arc::new(Mutex::new(HashMap::new())),
+            presence: std::sync::Arc::new(presence::Presence::new(std::time::Duration::from_secs(
+                1,
+            ))),
+            typing: std::sync::Arc::new(typing::TypingTracker::new(
+                std::time::Duration::from_secs(2),
+            )),
         })
     }
 }
@@ -88,6 +98,7 @@ pub fn build_router(state: AppState) -> Router {
         .route("/api/rooms", get(list_rooms).post(create_room))
         .route("/api/dm/:user_id", get(get_dm))
         .route("/api/messages", post(post_message).get(list_messages))
+        .route("/api/read_pointer", post(update_read_pointer))
         .layer(middleware::from_fn_with_state(
             state.clone(),
             auth_middleware,
@@ -559,7 +570,7 @@ async fn create_room(
 struct RoomWithUnread {
     #[serde(flatten)]
     room: rooms::Room,
-    unread_count: i64,
+    unread_count: u32,
 }
 
 async fn list_rooms(
@@ -572,15 +583,17 @@ async fn list_rooms(
         .map_err(|_| err(StatusCode::INTERNAL_SERVER_ERROR, "db"))?;
     let rooms = rooms::list_rooms_for_user(&conn, user.id)
         .map_err(|_| err(StatusCode::INTERNAL_SERVER_ERROR, "db"))?;
-    Ok(Json(
-        rooms
-            .into_iter()
-            .map(|room| RoomWithUnread {
+    let items = rooms
+        .into_iter()
+        .map(|room| {
+            let unread = reads::unread_count(&conn, user.id, &room.id).unwrap_or(0);
+            RoomWithUnread {
                 room,
-                unread_count: 0,
-            })
-            .collect(),
-    ))
+                unread_count: unread,
+            }
+        })
+        .collect();
+    Ok(Json(items))
 }
 
 async fn get_dm(
@@ -607,6 +620,47 @@ async fn get_dm(
     let room = rooms::get_or_create_dm_room(&conn, user.id, other_id)
         .map_err(|_| err(StatusCode::INTERNAL_SERVER_ERROR, "db"))?;
     Ok((StatusCode::OK, Json(room)))
+}
+
+#[derive(Deserialize)]
+struct ReadPointerReq {
+    room_id: Uuid,
+    message_id: Option<Uuid>,
+    timestamp: Option<i64>,
+}
+
+async fn update_read_pointer(
+    State(state): State<AppState>,
+    Extension(user): Extension<auth::User>,
+    Json(req): Json<ReadPointerReq>,
+) -> Result<StatusCode, (StatusCode, Json<ErrorResp>)> {
+    let conn = state
+        .pool
+        .get()
+        .map_err(|_| err(StatusCode::INTERNAL_SERVER_ERROR, "db"))?;
+    let allowed = rooms::user_can_access_room(&conn, &req.room_id, user.id)
+        .map_err(|_| err(StatusCode::INTERNAL_SERVER_ERROR, "db"))?;
+    if !allowed {
+        return Err(err(StatusCode::FORBIDDEN, "forbidden"));
+    }
+    let ts = if let Some(mid) = req.message_id {
+        let mut stmt = conn
+            .prepare("SELECT created_at FROM messages WHERE id = ?1")
+            .map_err(|_| err(StatusCode::INTERNAL_SERVER_ERROR, "db"))?;
+        stmt.query_row([mid.to_string()], |row| row.get(0))
+            .map_err(|_| err(StatusCode::BAD_REQUEST, "message_not_found"))?
+    } else if let Some(ts) = req.timestamp {
+        ts
+    } else {
+        OffsetDateTime::now_utc().unix_timestamp()
+    };
+    reads::set_read_pointer(&conn, user.id, &req.room_id, ts)
+        .map_err(|_| err(StatusCode::INTERNAL_SERVER_ERROR, "db"))?;
+    let _ = state.event_tx.send(
+        serde_json::json!({"t":"unread","room_id":req.room_id,"user_id":user.id,"count":0})
+            .to_string(),
+    );
+    Ok(StatusCode::NO_CONTENT)
 }
 
 #[derive(Deserialize)]
@@ -642,9 +696,27 @@ async fn post_message(
         "empty_message" => err(StatusCode::BAD_REQUEST, "empty_message"),
         _ => err(StatusCode::INTERNAL_SERVER_ERROR, "db"),
     })?;
+    reads::set_read_pointer(&conn, user.id, &req.room_id, msg.created_at)
+        .map_err(|_| err(StatusCode::INTERNAL_SERVER_ERROR, "db"))?;
     let _ = state
         .event_tx
         .send(serde_json::json!({"t":"message","room_id":req.room_id,"message":msg}).to_string());
+    let members: Vec<u32> = state
+        .ws_members
+        .lock()
+        .get(&req.room_id)
+        .map(|s| s.iter().copied().collect())
+        .unwrap_or_default();
+    for uid in members {
+        if uid == user.id {
+            continue;
+        }
+        if let Ok(unread) = reads::unread_count(&conn, uid, &req.room_id) {
+            let _ = state.event_tx.send(
+                serde_json::json!({"t":"unread","room_id":req.room_id,"user_id":uid,"count":unread}).to_string(),
+            );
+        }
+    }
     Ok((StatusCode::CREATED, Json(msg)))
 }
 
@@ -698,6 +770,11 @@ async fn ws_handler(
 async fn handle_socket(stream: WebSocket, state: AppState, user: auth::User) {
     let (mut sender, mut receiver) = stream.split();
     let mut rx = BroadcastStream::new(state.event_tx.subscribe());
+    if state.presence.connect(user.id) {
+        let _ = state.event_tx.send(
+            serde_json::json!({"t":"presence","user_id":user.id,"state":"online"}).to_string(),
+        );
+    }
     let _ = sender.send(Message::Text("hello".into())).await;
     loop {
         tokio::select! {
@@ -715,6 +792,8 @@ async fn handle_socket(stream: WebSocket, state: AppState, user: auth::User) {
                                 let _ = sender.send(Message::Text(ev)).await;
                             }
                         }
+                    } else {
+                        let _ = sender.send(Message::Text(ev)).await;
                     }
                 }
             },
@@ -738,8 +817,32 @@ async fn handle_socket(stream: WebSocket, state: AppState, user: auth::User) {
                                                 let mut guard = state.ws_members.lock();
                                                 guard.entry(room_id).or_default().insert(user.id);
                                             }
-                                            let _ = sender.send(Message::Text("joined".into())).await;
+                                            let presence_map = state.presence.snapshot().into_iter().map(|(k,v)| (k.to_string(), v)).collect::<std::collections::HashMap<_,_>>();
+                                            let unread = state
+                                                .pool
+                                                .get()
+                                                .ok()
+                                                .and_then(|conn| reads::unread_count(&conn, user.id, &room_id).ok())
+                                                .unwrap_or(0);
+                                            let snap = serde_json::json!({"t":"snapshot","room_id":room_id,"presence":presence_map,"unread":unread});
+                                            let _ = sender.send(Message::Text(snap.to_string())).await;
                                             continue;
+                                        }
+                                    }
+                                }
+                            } else if v.get("t").and_then(|a| a.as_str()) == Some("typing") {
+                                if let Some(id_str) = v.get("room_id").and_then(|r| r.as_str()) {
+                                    if let Ok(room_id) = Uuid::parse_str(id_str) {
+                                        let joined = state
+                                            .ws_members
+                                            .lock()
+                                            .get(&room_id)
+                                            .map(|s| s.contains(&user.id))
+                                            .unwrap_or(false);
+                                        if joined && state.typing.typing(user.id, room_id) {
+                                            let _ = state.event_tx.send(
+                                                serde_json::json!({"t":"typing","room_id":room_id,"user_id":user.id}).to_string(),
+                                            );
                                         }
                                     }
                                 }
@@ -752,6 +855,18 @@ async fn handle_socket(stream: WebSocket, state: AppState, user: auth::User) {
             },
             else => break,
         }
+    }
+    {
+        let mut guard = state.ws_members.lock();
+        for members in guard.values_mut() {
+            members.remove(&user.id);
+        }
+        guard.retain(|_, v| !v.is_empty());
+    }
+    if state.presence.disconnect(user.id).await {
+        let _ = state.event_tx.send(
+            serde_json::json!({"t":"presence","user_id":user.id,"state":"offline"}).to_string(),
+        );
     }
 }
 

--- a/plugins/family_chat/src/db.rs
+++ b/plugins/family_chat/src/db.rs
@@ -67,6 +67,13 @@ CREATE TABLE IF NOT EXISTS reads (
   PRIMARY KEY (user_id, message_id)
 );
 
+CREATE TABLE IF NOT EXISTS read_pointers (
+  room_id TEXT NOT NULL REFERENCES rooms(id),
+  user_id INTEGER NOT NULL,
+  last_read_at INTEGER NOT NULL,
+  PRIMARY KEY (room_id, user_id)
+);
+
 CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(text_md, content='messages', content_rowid='rowid');
 CREATE TRIGGER IF NOT EXISTS messages_ai AFTER INSERT ON messages BEGIN
   INSERT INTO messages_fts(rowid, text_md) VALUES (new.rowid, new.text_md);

--- a/plugins/family_chat/src/lib.rs
+++ b/plugins/family_chat/src/lib.rs
@@ -9,5 +9,8 @@ pub mod housekeeping;
 pub mod messages;
 pub mod model;
 pub mod plugin;
+pub mod presence;
+pub mod reads;
 pub mod rooms;
+pub mod typing;
 pub mod ws;

--- a/plugins/family_chat/src/main.rs
+++ b/plugins/family_chat/src/main.rs
@@ -9,7 +9,10 @@ mod housekeeping;
 mod messages;
 mod model;
 mod plugin;
+mod presence;
+mod reads;
 mod rooms;
+mod typing;
 mod ws;
 
 use anyhow::Result;

--- a/plugins/family_chat/src/presence.rs
+++ b/plugins/family_chat/src/presence.rs
@@ -1,0 +1,77 @@
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::time::Duration;
+use tokio::time::sleep;
+
+pub struct Presence {
+    counts: Mutex<HashMap<u32, usize>>,
+    debounce: Duration,
+}
+
+impl Presence {
+    pub fn new(debounce: Duration) -> Self {
+        Self {
+            counts: Mutex::new(HashMap::new()),
+            debounce,
+        }
+    }
+
+    /// Register a connection. Returns true if user transitioned to online.
+    pub fn connect(&self, user_id: u32) -> bool {
+        let mut guard = self.counts.lock();
+        let c = guard.entry(user_id).or_insert(0);
+        *c += 1;
+        *c == 1
+    }
+
+    /// Deregister a connection. Returns true if user transitions to offline after debounce.
+    pub async fn disconnect(&self, user_id: u32) -> bool {
+        {
+            let mut guard = self.counts.lock();
+            if let Some(c) = guard.get_mut(&user_id) {
+                if *c > 0 {
+                    *c -= 1;
+                }
+            }
+        }
+        sleep(self.debounce).await;
+        let mut guard = self.counts.lock();
+        match guard.get(&user_id).copied() {
+            Some(0) | None => {
+                guard.remove(&user_id);
+                true
+            }
+            _ => false,
+        }
+    }
+
+    pub fn snapshot(&self) -> HashMap<u32, &'static str> {
+        let guard = self.counts.lock();
+        guard
+            .keys()
+            .copied()
+            .map(|id| (id, "online" as &'static str))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::time::{sleep, Duration};
+
+    #[tokio::test]
+    async fn state_machine() {
+        let presence = std::sync::Arc::new(Presence::new(Duration::from_millis(20)));
+        assert!(presence.connect(1));
+        let p = presence.clone();
+        let fut = tokio::spawn(async move { p.disconnect(1).await });
+        sleep(Duration::from_millis(10)).await;
+        // reconnect before debounce expiry
+        assert!(presence.connect(1));
+        sleep(Duration::from_millis(30)).await;
+        assert!(!fut.await.unwrap());
+        // final disconnect
+        assert!(presence.disconnect(1).await);
+    }
+}

--- a/plugins/family_chat/src/reads.rs
+++ b/plugins/family_chat/src/reads.rs
@@ -1,0 +1,62 @@
+use anyhow::Result;
+use rusqlite::{params, Connection, OptionalExtension};
+use uuid::Uuid;
+
+/// Update read pointer for a user and room.
+pub fn set_read_pointer(conn: &Connection, user_id: u32, room_id: &Uuid, ts: i64) -> Result<()> {
+    conn.execute(
+        "INSERT INTO read_pointers (room_id, user_id, last_read_at) VALUES (?1, ?2, ?3) \
+         ON CONFLICT(room_id, user_id) DO UPDATE SET last_read_at = excluded.last_read_at",
+        params![room_id.to_string(), user_id, ts],
+    )?;
+    Ok(())
+}
+
+/// Get last read timestamp for a user and room.
+pub fn get_last_read_at(conn: &Connection, user_id: u32, room_id: &Uuid) -> Result<i64> {
+    let mut stmt =
+        conn.prepare("SELECT last_read_at FROM read_pointers WHERE room_id = ?1 AND user_id = ?2")?;
+    let ts: Option<i64> = stmt
+        .query_row(params![room_id.to_string(), user_id], |row| row.get(0))
+        .optional()?;
+    Ok(ts.unwrap_or(0))
+}
+
+/// Calculate unread count for a user in a room.
+pub fn unread_count(conn: &Connection, user_id: u32, room_id: &Uuid) -> Result<u32> {
+    let last = get_last_read_at(conn, user_id, room_id)?;
+    let mut stmt = conn.prepare(
+        "SELECT COUNT(*) FROM messages WHERE room_id = ?1 AND created_at > ?2 AND author_id <> ?3",
+    )?;
+    let count: u32 = stmt.query_row(
+        params![room_id.to_string(), last, user_id.to_string()],
+        |row| row.get::<_, u32>(0),
+    )?;
+    Ok(count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{db, messages};
+    use time::OffsetDateTime;
+
+    #[test]
+    fn last_read_math() {
+        let conn = db::init_db(":memory:").unwrap();
+        let room_id = Uuid::new_v4();
+        conn.execute(
+            "INSERT INTO rooms (id, slug, name, is_dm, created_at) VALUES (?1, 'r', 'R', 0, 0)",
+            params![room_id.to_string()],
+        )
+        .unwrap();
+        let _m1 = messages::create_message(&conn, &room_id, 1, "m1", None).unwrap();
+        let m2 = messages::create_message(&conn, &room_id, 2, "m2", None).unwrap();
+        assert_eq!(unread_count(&conn, 1, &room_id).unwrap(), 1);
+        set_read_pointer(&conn, 1, &room_id, m2.created_at).unwrap();
+        assert_eq!(unread_count(&conn, 1, &room_id).unwrap(), 0);
+        let now = OffsetDateTime::now_utc().unix_timestamp();
+        set_read_pointer(&conn, 1, &room_id, now).unwrap();
+        assert_eq!(get_last_read_at(&conn, 1, &room_id).unwrap(), now);
+    }
+}

--- a/plugins/family_chat/src/typing.rs
+++ b/plugins/family_chat/src/typing.rs
@@ -1,0 +1,47 @@
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+use uuid::Uuid;
+
+pub struct TypingTracker {
+    last: Mutex<HashMap<(u32, Uuid), Instant>>,
+    debounce: Duration,
+}
+
+impl TypingTracker {
+    pub fn new(debounce: Duration) -> Self {
+        Self {
+            last: Mutex::new(HashMap::new()),
+            debounce,
+        }
+    }
+
+    /// Register a typing action. Returns true if event should be broadcast.
+    pub fn typing(&self, user_id: u32, room_id: Uuid) -> bool {
+        let mut guard = self.last.lock();
+        let key = (user_id, room_id);
+        let now = Instant::now();
+        let should = match guard.get(&key) {
+            Some(&prev) => now.duration_since(prev) >= self.debounce,
+            None => true,
+        };
+        if should {
+            guard.insert(key, now);
+        }
+        should
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn debounce_logic() {
+        let tracker = TypingTracker::new(Duration::from_secs(2));
+        let room = Uuid::nil();
+        assert!(tracker.typing(1, room));
+        assert!(!tracker.typing(1, room));
+    }
+}

--- a/plugins/family_chat/tests/realtime.rs
+++ b/plugins/family_chat/tests/realtime.rs
@@ -1,0 +1,241 @@
+use family_chat::api::{build_router, AppState};
+use family_chat::config::Config;
+use futures::{SinkExt, StreamExt};
+use std::net::{SocketAddr, TcpListener};
+use tokio::task::JoinHandle;
+use tokio_tungstenite::{
+    connect_async, tungstenite::client::IntoClientRequest, tungstenite::Message as WsMessage,
+};
+use uuid::Uuid;
+
+async fn spawn_server() -> (SocketAddr, JoinHandle<()>, AppState, tempfile::TempDir) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    listener.set_nonblocking(true).unwrap();
+    let tmp = tempfile::tempdir().unwrap();
+    let config = Config {
+        bind: addr.to_string(),
+        data_dir: tmp.path().to_path_buf(),
+        max_upload_mb: 5,
+    };
+    let state = AppState::new(config).await.unwrap();
+    let app = build_router(state.clone());
+    let server = tokio::spawn(async move {
+        axum::Server::from_tcp(listener)
+            .unwrap()
+            .serve(app.into_make_service())
+            .await
+            .unwrap();
+    });
+    (addr, server, state, tmp)
+}
+
+#[tokio::test]
+async fn presence_typing_unread_flow() {
+    let (addr, server, _state, _tmp) = spawn_server().await;
+    let client = reqwest::Client::new();
+    let body = serde_json::json!({
+        "passphrase": "supersecret",
+        "users": [
+            {"username":"admin","display_name":"Admin","admin":true},
+            {"username":"alice","display_name":"Alice","admin":false},
+            {"username":"bob","display_name":"Bob","admin":false}
+        ]
+    });
+    client
+        .post(format!("http://{}/api/bootstrap", addr))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    let resp = client
+        .post(format!("http://{}/api/login", addr))
+        .json(&serde_json::json!({"username":"alice","passphrase":"supersecret"}))
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success());
+    let alice_token = resp.json::<serde_json::Value>().await.unwrap()["token"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let resp = client
+        .post(format!("http://{}/api/login", addr))
+        .json(&serde_json::json!({"username":"bob","passphrase":"supersecret"}))
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success());
+    let bob_token = resp.json::<serde_json::Value>().await.unwrap()["token"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let resp = client
+        .post(format!("http://{}/api/rooms", addr))
+        .bearer_auth(&alice_token)
+        .json(&serde_json::json!({"name":"General","slug":"general"}))
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success());
+    let room_id = resp.json::<serde_json::Value>().await.unwrap()["id"]
+        .as_str()
+        .unwrap()
+        .parse::<Uuid>()
+        .unwrap();
+
+    // Bob connects first
+    let mut bob_req = format!("ws://{}/ws", addr).into_client_request().unwrap();
+    bob_req.headers_mut().append(
+        "Authorization",
+        format!("Bearer {}", bob_token).parse().unwrap(),
+    );
+    let (mut bob_ws, _) = connect_async(bob_req).await.unwrap();
+    bob_ws.next().await; // hello
+    bob_ws.next().await; // presence for Bob
+
+    // Alice connects
+    let mut alice_req = format!("ws://{}/ws", addr).into_client_request().unwrap();
+    alice_req.headers_mut().append(
+        "Authorization",
+        format!("Bearer {}", alice_token).parse().unwrap(),
+    );
+    let (mut alice_ws, _) = connect_async(alice_req).await.unwrap();
+    alice_ws.next().await; // hello
+
+    // Bob should see Alice online
+    let ev = bob_ws.next().await.unwrap().unwrap().into_text().unwrap();
+    let v: serde_json::Value = serde_json::from_str(&ev).unwrap();
+    assert_eq!(v["t"], "presence");
+    assert_eq!(v["user_id"], 2);
+    assert_eq!(v["state"], "online");
+
+    // Alice disconnects
+    alice_ws.close(None).await.unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(1200)).await;
+    let ev = bob_ws.next().await.unwrap().unwrap().into_text().unwrap();
+    let v: serde_json::Value = serde_json::from_str(&ev).unwrap();
+    assert_eq!(v["state"], "offline");
+
+    // Typing: reconnect Alice and join room
+    let mut alice_req = format!("ws://{}/ws", addr).into_client_request().unwrap();
+    alice_req.headers_mut().append(
+        "Authorization",
+        format!("Bearer {}", alice_token).parse().unwrap(),
+    );
+    let (mut alice_ws, _) = connect_async(alice_req).await.unwrap();
+    alice_ws.next().await; // hello
+    alice_ws
+        .send(WsMessage::Text(format!(
+            "{{\"action\":\"join\",\"room_id\":\"{}\"}}",
+            room_id
+        )))
+        .await
+        .unwrap();
+    bob_ws
+        .send(WsMessage::Text(format!(
+            "{{\"action\":\"join\",\"room_id\":\"{}\"}}",
+            room_id
+        )))
+        .await
+        .unwrap();
+    loop {
+        if let Some(Ok(WsMessage::Text(txt))) = bob_ws.next().await {
+            let val: serde_json::Value = serde_json::from_str(&txt).unwrap();
+            if val["t"] == "snapshot" {
+                break;
+            }
+        }
+    }
+
+    alice_ws
+        .send(WsMessage::Text(format!(
+            "{{\"t\":\"typing\",\"room_id\":\"{}\"}}",
+            room_id
+        )))
+        .await
+        .unwrap();
+    alice_ws
+        .send(WsMessage::Text(format!(
+            "{{\"t\":\"typing\",\"room_id\":\"{}\"}}",
+            room_id
+        )))
+        .await
+        .unwrap();
+    use tokio::time::{timeout, Duration};
+    let msg = timeout(Duration::from_millis(500), bob_ws.next())
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    if let WsMessage::Text(txt) = msg {
+        let v: serde_json::Value = serde_json::from_str(&txt).unwrap();
+        assert_eq!(v["t"], "typing");
+    }
+    assert!(timeout(Duration::from_millis(500), bob_ws.next())
+        .await
+        .is_err());
+
+    // Unread test: Bob disconnects
+    bob_ws.close(None).await.unwrap();
+    for _ in 0..3 {
+        client
+            .post(format!("http://{}/api/messages", addr))
+            .bearer_auth(&alice_token)
+            .json(&serde_json::json!({"room_id":room_id,"text_md":"hi"}))
+            .send()
+            .await
+            .unwrap();
+    }
+    let mut bob_req = format!("ws://{}/ws", addr).into_client_request().unwrap();
+    bob_req.headers_mut().append(
+        "Authorization",
+        format!("Bearer {}", bob_token).parse().unwrap(),
+    );
+    let (mut bob_ws, _) = connect_async(bob_req).await.unwrap();
+    bob_ws.next().await; // hello
+    bob_ws
+        .send(WsMessage::Text(format!(
+            "{{\"action\":\"join\",\"room_id\":\"{}\"}}",
+            room_id
+        )))
+        .await
+        .unwrap();
+    let snap = loop {
+        if let Some(Ok(WsMessage::Text(txt))) = bob_ws.next().await {
+            let val: serde_json::Value = serde_json::from_str(&txt).unwrap();
+            if val["t"] == "snapshot" {
+                break val;
+            }
+        }
+    };
+    assert_eq!(snap["unread"], 3);
+
+    client
+        .post(format!("http://{}/api/read_pointer", addr))
+        .bearer_auth(&bob_token)
+        .json(&serde_json::json!({"room_id":room_id}))
+        .send()
+        .await
+        .unwrap();
+    let resp = client
+        .get(format!("http://{}/api/rooms", addr))
+        .bearer_auth(&bob_token)
+        .send()
+        .await
+        .unwrap();
+    let rooms: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(rooms[0]["unread_count"], 0);
+
+    client
+        .post(format!("http://{}/api/messages", addr))
+        .bearer_auth(&alice_token)
+        .json(&serde_json::json!({"room_id":room_id,"text_md":"again"}))
+        .send()
+        .await
+        .unwrap();
+    let ev = bob_ws.next().await.unwrap().unwrap().into_text().unwrap();
+    let v: serde_json::Value = serde_json::from_str(&ev).unwrap();
+    assert_eq!(v["t"], "unread");
+    server.abort();
+}


### PR DESCRIPTION
## Summary
- track websocket presence with debounce and broadcast transitions
- throttle typing notifications and unread counters with read pointers
- cover real-time presence/typing/unread flow with integration test

## Testing
- `cargo fmt --all -- --check`
- `cargo test`
- `cargo test --test realtime`


------
https://chatgpt.com/codex/tasks/task_e_689cbdfd6484833283f1770b703bb758