### PR TITLE
docs: refresh readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,18 @@
 # HomeCore
 
-Rust workspace demonstrating a simple home automation core that loads plugins which communicate over JSON and stdio.
+Rust workspace for a modular home automation system. The `core` process hosts
+services such as logging, timers and storage, and loads external plugins over a
+JSON/stdio protocol defined in the `plugin_api` crate.
 
-## Build
+## Building
+
+Build the entire workspace:
 
 ```
-cargo build
+cargo build --workspace
 ```
 
-## Run
+## Running the core
 
 Start the core and load plugins from the `plugins/` directory:
 
@@ -22,14 +26,35 @@ List discovered plugins:
 cargo run -p core -- plugin list --plugins-dir ./plugins
 ```
 
-## Sample plugin
+## Plugins
 
-The sample plugin subscribes to `timer.tick` and logs a message every second. It also handles a `sample.ping` request and echoes the payload.
+* `sample_plugin` – Demonstrates the plugin protocol by subscribing to
+  `timer.tick`, logging a message every second and replying to `sample.ping`
+  requests. Run it manually with:
+
+  ```
+  cargo run -p sample_plugin -- --stdio
+  ```
+
+* `family_chat` – A chat service with rooms, presence, file uploads and a
+  React/Vite web UI embedded into the binary. See
+  [`plugins/family_chat/README.md`](plugins/family_chat/README.md) for build and
+  run instructions.
 
 ## Tests
 
+Run all Rust tests:
+
 ```
 cargo test --workspace
+```
+
+The `family_chat` web UI also provides a JavaScript test suite:
+
+```
+cd plugins/family_chat/webui
+npm ci
+npm test
 ```
 
 ## CI
@@ -40,8 +65,9 @@ Native:
 cargo test --workspace && cargo build --release
 ```
 
-Aarch64 (lokal):
+Aarch64 (local):
 
 ```
 cargo install cross && cross build --release --target aarch64-unknown-linux-gnu
 ```
+

--- a/plugins/family_chat/README.md
+++ b/plugins/family_chat/README.md
@@ -1,8 +1,24 @@
 # Family Chat Plugin
 
-This plugin now ships a small React-based web UI that is embedded into the
-Rust binary. The UI is built with Vite and TypeScript and compiled to static
-assets under `webui/dist` which are embedded at build time.
+A real-time chat service for HomeCore. It exposes a JSON/HTTP API and a
+WebSocket endpoint backed by an embedded SQLite database and ships a
+React/Vite web UI that is embedded into the binary at compile time.
+
+## Features
+
+* Multiple rooms and direct messages
+* Presence, typing indicators and read receipts
+* File uploads stored under a configurable data directory
+* Full text search over messages
+* Runs standalone over HTTP or as a plugin via the HomeCore stdio protocol
+
+## Configuration
+
+The server reads the following environment variables:
+
+* `BIND` – address to bind the HTTP server (default `0.0.0.0:8787`)
+* `DATA_DIR` – directory for the SQLite database and uploaded files
+* `MAX_UPLOAD_MB` – maximum upload size in megabytes (default `5`)
 
 ## Building
 
@@ -45,3 +61,4 @@ Run the backend and frontend test suites:
 cargo test -p family_chat
 cd plugins/family_chat/webui && npm test
 ```
+


### PR DESCRIPTION
## Summary
- clarify plugin architecture and available plugins in main README
- document features and configuration for family_chat plugin

## Testing
- `cargo test --workspace`
- `cd plugins/family_chat/webui && npm ci && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dd449e6b88332bae7339408dd3684