### PR TITLE
Add configuration file and bootstrap logic to family_chat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ plugins/family_chat/webui/dist/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Local configuration
+config/family_chat.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,6 +392,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,6 +528,7 @@ dependencies = [
  "rust-embed",
  "serde",
  "serde_json",
+ "serial_test",
  "sha2",
  "tempfile",
  "time",
@@ -522,6 +536,7 @@ dependencies = [
  "tokio-stream",
  "tokio-tungstenite",
  "tokio-util",
+ "toml",
  "tower",
  "tracing",
  "tracing-subscriber",
@@ -1927,6 +1942,31 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e56dd856803e253c8f298af3f4d7eb0ae5e23a737252cd90bb4f3b435033b2d"
+dependencies = [
+ "dashmap",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/config/family_chat.example.toml
+++ b/config/family_chat.example.toml
@@ -1,0 +1,11 @@
+# Sample configuration for Family Chat
+
+[bootstrap]
+# username = "admin"
+# password = "admin"
+
+[server]
+# port = 8787
+
+[logging]
+# enabled = true

--- a/plugins/family_chat/Cargo.toml
+++ b/plugins/family_chat/Cargo.toml
@@ -40,7 +40,9 @@ futures = "0.3"
 url = "2"
 infer = "0.13"
 image = { version = "0.24", default-features = false, features = ["png", "jpeg"] }
+toml = { version = "0.8", features = ["parse"] }
 
 [dev-dependencies]
 tempfile = "3"
 reqwest = { version = "0.11", features = ["json", "multipart"] }
+serial_test = "2"

--- a/plugins/family_chat/README.md
+++ b/plugins/family_chat/README.md
@@ -14,11 +14,28 @@ React/Vite web UI that is embedded into the binary at compile time.
 
 ## Configuration
 
-The server reads the following environment variables:
+Family Chat reads configuration from a file, environment variables and CLI flags
+with the following precedence:
 
-* `BIND` – address to bind the HTTP server (default `0.0.0.0:8787`)
+`CLI` > `ENV` > `config file` > built-in defaults.
+
+The default config file location is `config/family_chat.toml`. Override with the
+`--config` flag or the `FAMILY_CHAT_CONFIG` environment variable. A sample file
+is provided at `config/family_chat.example.toml`.
+
+Supported settings:
+
+* `bootstrap.username` / `bootstrap.password` – on first run, create this admin
+  account. **The default `admin`/`admin` credentials are for local development
+  only.**
+* `server.port` – port to bind the HTTP/WS server (default `8787`). Host may be
+  overridden with `--bind` or the `BIND` env variable.
+* `logging.enabled` – when `false`, only warnings and errors are logged.
 * `DATA_DIR` – directory for the SQLite database and uploaded files
 * `MAX_UPLOAD_MB` – maximum upload size in megabytes (default `5`)
+
+Environment variables `FAMILY_CHAT_PORT` and `FAMILY_CHAT_LOGGING` may override
+the port and logging settings respectively.
 
 ## Building
 

--- a/plugins/family_chat/src/api.rs
+++ b/plugins/family_chat/src/api.rs
@@ -20,6 +20,7 @@ use futures::{SinkExt, StreamExt};
 use parking_lot::Mutex;
 use r2d2::Pool;
 use r2d2_sqlite::SqliteConnectionManager;
+use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{HashMap, HashSet},
@@ -80,11 +81,39 @@ impl AppState {
         }
         let (tx, _rx) = broadcast::channel(100);
         let auth_file = config.data_dir.join("auth.json");
-        let auth = if let Ok(bytes) = tokio::fs::read(&auth_file).await {
+        let mut auth = if let Ok(bytes) = tokio::fs::read(&auth_file).await {
             serde_json::from_slice(&bytes).ok()
         } else {
             None
         };
+        if auth.is_none() {
+            if let Some(bs) = &config.bootstrap {
+                let hash =
+                    auth::hash_passphrase(&bs.password).map_err(|_| anyhow::anyhow!("hash"))?;
+                let mut secret = vec![0u8; 32];
+                rand::thread_rng().fill_bytes(&mut secret);
+                let user = auth::User {
+                    id: 1,
+                    username: bs.username.to_lowercase(),
+                    display_name: bs.username.clone(),
+                    admin: true,
+                    disabled: false,
+                    avatar_url: None,
+                    must_change_password: true,
+                };
+                let cfg = auth::AuthConfig {
+                    passphrase_hash: hash,
+                    jwt_secret: STANDARD.encode(&secret),
+                    users: vec![user],
+                    created_at: OffsetDateTime::now_utc().unix_timestamp(),
+                };
+                if let Some(dir) = auth_file.parent() {
+                    tokio::fs::create_dir_all(dir).await?;
+                }
+                tokio::fs::write(&auth_file, serde_json::to_vec(&cfg)?).await?;
+                auth = Some(cfg);
+            }
+        }
         Ok(Self {
             pool,
             file_dir,
@@ -324,6 +353,7 @@ async fn bootstrap(
             admin: u.admin,
             disabled: false,
             avatar_url: avatar,
+            must_change_password: false,
         });
         next_id += 1;
     }
@@ -457,6 +487,7 @@ async fn create_user(
         admin: false,
         disabled: false,
         avatar_url: avatar,
+        must_change_password: false,
     };
     cfg.add_user(user.clone())
         .map_err(|_| err(StatusCode::CONFLICT, "username_taken"))?;
@@ -1054,11 +1085,9 @@ async fn handle_socket(stream: WebSocket, state: AppState, user: auth::User) {
 }
 
 /// Run the HTTP server bound to the provided address.
-pub async fn run_http_server(bind: String) -> Result<()> {
-    let mut config = Config::from_env();
-    config.bind = bind.clone();
+pub async fn run_http_server(config: Config) -> Result<()> {
+    let addr: SocketAddr = config.bind.parse()?;
     let state = AppState::new(config).await?;
-    let addr: SocketAddr = bind.parse()?;
     axum::Server::bind(&addr)
         .serve(build_router(state).into_make_service())
         .await?;

--- a/plugins/family_chat/src/auth.rs
+++ b/plugins/family_chat/src/auth.rs
@@ -26,6 +26,8 @@ pub struct User {
     pub disabled: bool,
     #[serde(default)]
     pub avatar_url: Option<String>,
+    #[serde(default)]
+    pub must_change_password: bool,
 }
 
 /// Persistent authentication configuration.
@@ -219,6 +221,7 @@ mod tests {
             admin: false,
             disabled: false,
             avatar_url: None,
+            must_change_password: false,
         })
         .unwrap();
         assert!(cfg
@@ -229,6 +232,7 @@ mod tests {
                 admin: false,
                 disabled: false,
                 avatar_url: None,
+                must_change_password: false,
             })
             .is_err());
     }
@@ -245,6 +249,7 @@ mod tests {
                 admin: true,
                 disabled: false,
                 avatar_url: None,
+                must_change_password: false,
             }],
             created_at: 0,
         };

--- a/plugins/family_chat/src/config.rs
+++ b/plugins/family_chat/src/config.rs
@@ -1,8 +1,45 @@
-#![allow(dead_code)]
+use std::{fs, path::PathBuf};
 
-use std::path::PathBuf;
+use anyhow::{Context, Result};
+use clap::Parser;
+use serde::Deserialize;
 
-/// Runtime configuration for the server.
+/// Command line options for the plugin.
+#[derive(Parser, Debug, Default)]
+pub struct Cli {
+    /// Run with stdio protocol used by the core.
+    #[arg(long)]
+    pub stdio: bool,
+    /// Override bind address (host:port).
+    #[arg(long)]
+    pub bind: Option<String>,
+    /// Override server port.
+    #[arg(long)]
+    pub port: Option<u16>,
+    /// Enable or disable logging (true/false).
+    #[arg(long)]
+    pub logging: Option<bool>,
+    /// Path to configuration file.
+    #[arg(long)]
+    pub config: Option<PathBuf>,
+}
+
+#[derive(Clone)]
+pub struct Bootstrap {
+    pub username: String,
+    pub password: String,
+}
+
+impl std::fmt::Debug for Bootstrap {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Bootstrap")
+            .field("username", &self.username)
+            .field("password", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Runtime configuration for the server resolved from file, env and CLI.
 #[derive(Clone, Debug)]
 pub struct Config {
     /// Address to bind the HTTP server to.
@@ -11,13 +48,127 @@ pub struct Config {
     pub data_dir: PathBuf,
     /// Maximum upload size in megabytes.
     pub max_upload_mb: u64,
+    /// Whether verbose logging is enabled.
+    pub logging_enabled: bool,
+    /// Bootstrap credentials, consumed on first run.
+    pub bootstrap: Option<Bootstrap>,
+}
+
+#[derive(Deserialize, Default)]
+struct FileConfig {
+    #[serde(default)]
+    bootstrap: Option<FileBootstrap>,
+    #[serde(default)]
+    server: FileServer,
+    #[serde(default)]
+    logging: FileLogging,
+}
+
+#[derive(Deserialize)]
+struct FileBootstrap {
+    username: String,
+    password: String,
+}
+
+#[derive(Deserialize)]
+struct FileServer {
+    #[serde(default = "default_port")]
+    port: u16,
+}
+
+#[derive(Deserialize)]
+struct FileLogging {
+    #[serde(default = "default_logging")]
+    enabled: bool,
+}
+
+fn default_port() -> u16 {
+    8787
+}
+
+fn default_logging() -> bool {
+    true
+}
+
+impl Default for FileServer {
+    fn default() -> Self {
+        Self {
+            port: default_port(),
+        }
+    }
+}
+
+impl Default for FileLogging {
+    fn default() -> Self {
+        Self {
+            enabled: default_logging(),
+        }
+    }
 }
 
 impl Config {
-    /// Load configuration from environment variables, falling back to
-    /// sensible defaults when not present.
-    pub fn from_env() -> Self {
-        let bind = std::env::var("BIND").unwrap_or_else(|_| "0.0.0.0:8787".into());
+    /// Resolve configuration from CLI, environment variables, config file and defaults.
+    pub fn load(cli: &Cli) -> Result<Self> {
+        // built-in defaults
+        let mut port = default_port();
+        let mut logging = default_logging();
+        let mut bootstrap: Option<Bootstrap> = None;
+
+        // config file path precedence: CLI -> ENV -> default
+        let config_path = cli
+            .config
+            .clone()
+            .or_else(|| std::env::var("FAMILY_CHAT_CONFIG").ok().map(PathBuf::from))
+            .unwrap_or_else(|| PathBuf::from("config/family_chat.toml"));
+
+        if let Ok(bytes) = fs::read(&config_path) {
+            let contents = String::from_utf8_lossy(&bytes);
+            let file_cfg: FileConfig = toml::from_str(&contents).context("invalid config file")?;
+            if let Some(b) = file_cfg.bootstrap {
+                bootstrap = Some(Bootstrap {
+                    username: b.username,
+                    password: b.password,
+                });
+            }
+            port = file_cfg.server.port;
+            logging = file_cfg.logging.enabled;
+        }
+
+        // environment overrides
+        if let Ok(p) = std::env::var("FAMILY_CHAT_PORT") {
+            if let Ok(p) = p.parse::<u16>() {
+                port = p;
+            }
+        }
+        if let Ok(l) = std::env::var("FAMILY_CHAT_LOGGING") {
+            if let Ok(l) = l.parse::<bool>() {
+                logging = l;
+            }
+        }
+
+        // CLI overrides
+        if let Some(p) = cli.port {
+            port = p;
+        }
+        if let Some(l) = cli.logging {
+            logging = l;
+        }
+
+        // validate port range
+        if !(1024..=65535).contains(&port) {
+            anyhow::bail!("invalid_port");
+        }
+
+        // bind address precedence for host override
+        let bind = if let Some(b) = &cli.bind {
+            b.clone()
+        } else if let Ok(b) = std::env::var("BIND") {
+            b
+        } else {
+            format!("127.0.0.1:{}", port)
+        };
+
+        // existing env variables for data dir and upload limit
         let data_dir = std::env::var("DATA_DIR")
             .map(PathBuf::from)
             .unwrap_or_else(|_| default_data_dir());
@@ -25,11 +176,14 @@ impl Config {
             .ok()
             .and_then(|v| v.parse().ok())
             .unwrap_or(5);
-        Self {
+
+        Ok(Self {
             bind,
             data_dir,
             max_upload_mb,
-        }
+            logging_enabled: logging,
+            bootstrap,
+        })
     }
 
     /// Helper to return the upload limit in bytes.
@@ -54,15 +208,105 @@ pub fn default_data_dir() -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
+    use std::fs;
 
     #[test]
-    fn parses_env_config() {
-        std::env::set_var("BIND", "127.0.0.1:9999");
-        std::env::set_var("DATA_DIR", "/tmp/data");
-        std::env::set_var("MAX_UPLOAD_MB", "10");
-        let cfg = Config::from_env();
-        assert_eq!(cfg.bind, "127.0.0.1:9999");
-        assert_eq!(cfg.data_dir, PathBuf::from("/tmp/data"));
-        assert_eq!(cfg.max_upload_mb, 10);
+    #[serial]
+    fn valid_config_parses() {
+        std::env::remove_var("FAMILY_CHAT_PORT");
+        std::env::remove_var("FAMILY_CHAT_LOGGING");
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cfg.toml");
+        fs::write(&path, "[server]\nport=5555\n[logging]\nenabled=false\n").unwrap();
+        let cli = Cli {
+            config: Some(path),
+            ..Default::default()
+        };
+        let cfg = Config::load(&cli).unwrap();
+        assert_eq!(cfg.bind, "127.0.0.1:5555");
+        assert!(!cfg.logging_enabled);
+    }
+
+    #[test]
+    #[serial]
+    fn invalid_port_fails() {
+        std::env::remove_var("FAMILY_CHAT_PORT");
+        std::env::remove_var("FAMILY_CHAT_LOGGING");
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cfg.toml");
+        fs::write(&path, "[server]\nport=80\n").unwrap();
+        let cli = Cli {
+            config: Some(path),
+            ..Default::default()
+        };
+        assert!(Config::load(&cli).is_err());
+    }
+
+    #[test]
+    #[serial]
+    fn missing_keys_defaults() {
+        std::env::remove_var("FAMILY_CHAT_PORT");
+        std::env::remove_var("FAMILY_CHAT_LOGGING");
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cfg.toml");
+        fs::write(&path, "").unwrap();
+        let cli = Cli {
+            config: Some(path),
+            ..Default::default()
+        };
+        let cfg = Config::load(&cli).unwrap();
+        assert_eq!(cfg.bind, "127.0.0.1:8787");
+        assert!(cfg.logging_enabled);
+    }
+
+    #[test]
+    #[serial]
+    fn precedence_cli_env_file() {
+        std::env::remove_var("FAMILY_CHAT_LOGGING");
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cfg.toml");
+        fs::write(&path, "[server]\nport=1111\n").unwrap();
+        std::env::set_var("FAMILY_CHAT_PORT", "2222");
+        let cli = Cli {
+            config: Some(path),
+            port: Some(3333),
+            ..Default::default()
+        };
+        let cfg = Config::load(&cli).unwrap();
+        assert_eq!(cfg.bind, "127.0.0.1:3333");
+        std::env::remove_var("FAMILY_CHAT_PORT");
+    }
+
+    #[test]
+    #[serial]
+    fn file_value_used_when_no_overrides() {
+        std::env::remove_var("FAMILY_CHAT_PORT");
+        std::env::remove_var("FAMILY_CHAT_LOGGING");
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cfg.toml");
+        fs::write(&path, "[server]\nport=4444\n").unwrap();
+        let cli = Cli {
+            config: Some(path),
+            ..Default::default()
+        };
+        let cfg = Config::load(&cli).unwrap();
+        assert_eq!(cfg.bind, "127.0.0.1:4444");
+    }
+
+    #[test]
+    #[serial]
+    fn logging_toggle() {
+        std::env::remove_var("FAMILY_CHAT_PORT");
+        std::env::remove_var("FAMILY_CHAT_LOGGING");
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cfg.toml");
+        fs::write(&path, "[logging]\nenabled=false\n").unwrap();
+        let cli = Cli {
+            config: Some(path),
+            ..Default::default()
+        };
+        let cfg = Config::load(&cli).unwrap();
+        assert!(!cfg.logging_enabled);
     }
 }

--- a/plugins/family_chat/src/core_bridge.rs
+++ b/plugins/family_chat/src/core_bridge.rs
@@ -1,3 +1,4 @@
+use crate::config::Config;
 use anyhow::Result;
 use plugin_api::{Envelope, Kind, Metadata};
 use serde_json::json;
@@ -18,7 +19,7 @@ pub struct NullCoreBridge;
 impl CoreBridge for NullCoreBridge {}
 
 /// Run the stdio protocol handshake with the core and then start the HTTP server.
-pub async fn run_stdio(bind: &str) -> Result<()> {
+pub async fn run_stdio(config: Config) -> Result<()> {
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
     let mut reader = BufReader::new(stdin);
@@ -65,9 +66,9 @@ pub async fn run_stdio(bind: &str) -> Result<()> {
     let _ = read(&mut reader).await?; // response
 
     // spawn HTTP server
-    let bind = bind.to_string();
+    let cfg = config.clone();
     tokio::spawn(async move {
-        let _ = crate::api::run_http_server(bind).await;
+        let _ = crate::api::run_http_server(cfg).await;
     });
 
     // event loop; respond to plugin.stop and then exit

--- a/plugins/family_chat/src/main.rs
+++ b/plugins/family_chat/src/main.rs
@@ -18,21 +18,15 @@ mod ws;
 use anyhow::Result;
 use clap::Parser;
 
-#[derive(Parser)]
-struct Opts {
-    /// Run with stdio protocol used by the core.
-    #[arg(long)]
-    stdio: bool,
-    /// Address to bind the HTTP server to when running standalone.
-    #[arg(long, default_value = "0.0.0.0:8787")]
-    bind: String,
-}
-
 #[tokio::main]
 async fn main() -> Result<()> {
-    tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::INFO)
-        .init();
-    let opts = Opts::parse();
-    plugin::run(opts.stdio, opts.bind).await
+    let cli = config::Cli::parse();
+    let cfg = config::Config::load(&cli)?;
+    let level = if cfg.logging_enabled {
+        tracing::Level::INFO
+    } else {
+        tracing::Level::WARN
+    };
+    tracing_subscriber::fmt().with_max_level(level).init();
+    plugin::run(cli.stdio, cfg).await
 }

--- a/plugins/family_chat/src/plugin.rs
+++ b/plugins/family_chat/src/plugin.rs
@@ -1,11 +1,13 @@
 use anyhow::Result;
 
+use crate::config::Config;
+
 /// Entry point for running the plugin either as a standalone HTTP server or
 /// via the homecore stdio protocol.
-pub async fn run(stdio: bool, bind: String) -> Result<()> {
+pub async fn run(stdio: bool, config: Config) -> Result<()> {
     if stdio {
-        crate::core_bridge::run_stdio(&bind).await
+        crate::core_bridge::run_stdio(config).await
     } else {
-        crate::api::run_http_server(bind).await
+        crate::api::run_http_server(config).await
     }
 }

--- a/plugins/family_chat/tests/bootstrap.rs
+++ b/plugins/family_chat/tests/bootstrap.rs
@@ -1,0 +1,56 @@
+use family_chat::{
+    api::{build_router, AppState},
+    config::{Bootstrap, Config},
+};
+use std::net::{SocketAddr, TcpListener};
+use tokio::task::JoinHandle;
+
+async fn spawn(cfg: Config) -> (SocketAddr, JoinHandle<()>) {
+    let addr: SocketAddr = cfg.bind.parse().unwrap();
+    let state = AppState::new(cfg).await.unwrap();
+    let app = build_router(state);
+    let server = tokio::spawn(async move {
+        axum::Server::bind(&addr)
+            .serve(app.into_make_service())
+            .await
+            .unwrap();
+    });
+    (addr, server)
+}
+
+#[tokio::test]
+async fn bootstrap_creates_admin_and_is_idempotent() {
+    let tmp = tempfile::tempdir().unwrap();
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let cfg = Config {
+        bind: format!("127.0.0.1:{}", port),
+        data_dir: tmp.path().to_path_buf(),
+        max_upload_mb: 5,
+        logging_enabled: true,
+        bootstrap: Some(Bootstrap {
+            username: "admin".into(),
+            password: "admin".into(),
+        }),
+    };
+    let (addr, server) = spawn(cfg.clone()).await;
+    let client = reqwest::Client::new();
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    let resp = client
+        .post(format!("http://{}/api/login", addr))
+        .json(&serde_json::json!({"username":"admin","passphrase":"admin"}))
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success());
+    let v: serde_json::Value = resp.json().await.unwrap();
+    assert!(v["user"]["admin"].as_bool().unwrap());
+    assert!(v["user"]["must_change_password"].as_bool().unwrap());
+    server.abort();
+
+    // bootstrap should not run again
+    let state2 = AppState::new(cfg).await.unwrap();
+    let guard = state2.auth.lock().await;
+    assert_eq!(guard.as_ref().unwrap().users.len(), 1);
+}

--- a/plugins/family_chat/tests/integration.rs
+++ b/plugins/family_chat/tests/integration.rs
@@ -23,6 +23,8 @@ async fn spawn_server() -> (SocketAddr, JoinHandle<()>, AppState, tempfile::Temp
         bind: addr.to_string(),
         data_dir: tmp.path().to_path_buf(),
         max_upload_mb: 5,
+        logging_enabled: true,
+        bootstrap: None,
     };
     let state = AppState::new(config).await.unwrap();
     let app = build_router(state.clone());

--- a/plugins/family_chat/tests/messages.rs
+++ b/plugins/family_chat/tests/messages.rs
@@ -19,6 +19,8 @@ async fn spawn_server() -> (SocketAddr, JoinHandle<()>, AppState, tempfile::Temp
         bind: addr.to_string(),
         data_dir: tmp.path().to_path_buf(),
         max_upload_mb: 5,
+        logging_enabled: true,
+        bootstrap: None,
     };
     let state = AppState::new(config).await.unwrap();
     let app = build_router(state.clone());

--- a/plugins/family_chat/tests/realtime.rs
+++ b/plugins/family_chat/tests/realtime.rs
@@ -17,6 +17,8 @@ async fn spawn_server() -> (SocketAddr, JoinHandle<()>, AppState, tempfile::Temp
         bind: addr.to_string(),
         data_dir: tmp.path().to_path_buf(),
         max_upload_mb: 5,
+        logging_enabled: true,
+        bootstrap: None,
     };
     let state = AppState::new(config).await.unwrap();
     let app = build_router(state.clone());


### PR DESCRIPTION
## Summary
- introduce TOML config loader with CLI > ENV > file > default precedence
- support bootstrap admin user, port selection, and logging toggle
- document usage and provide sample config

## Testing
- `cargo test -q`


------
https://chatgpt.com/codex/tasks/task_e_689eed86bb988332a04716cbdd928bde