### PR TITLE
Add Playwright E2E chat test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,23 @@ jobs:
       - name: Build UI
         working-directory: plugins/family_chat/webui
         run: npm run build
+      - name: Install E2E dependencies
+        working-directory: plugins/family_chat
+        run: npm ci
+      - name: Build plugin for E2E
+        run: cargo build -p family_chat --release
+      - name: Install Playwright browsers
+        working-directory: plugins/family_chat
+        run: npx playwright install --with-deps
+      - name: Run E2E tests
+        working-directory: plugins/family_chat
+        run: npx playwright test --reporter=line
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: plugins/family_chat/playwright-report
       - name: Format
         run: cargo fmt --all -- --check
       - name: Clippy

--- a/plugins/family_chat/README.md
+++ b/plugins/family_chat/README.md
@@ -65,3 +65,11 @@ cargo test -p family_chat
 cd plugins/family_chat/webui && npm test
 ```
 
+To run the end-to-end test that exercises the compiled UI and binary:
+
+```
+cd plugins/family_chat/webui && npm run build
+cargo build -p family_chat --release
+cd .. && npx playwright test
+```
+

--- a/plugins/family_chat/e2e/e2e_message_appears.spec.js
+++ b/plugins/family_chat/e2e/e2e_message_appears.spec.js
@@ -1,0 +1,74 @@
+const { test, expect } = require('@playwright/test');
+const { spawn } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { setTimeout: delay } = require('timers/promises');
+
+let proc;
+let port;
+let dataDir;
+
+async function waitForServer(url) {
+  for (let i = 0; i < 50; i++) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return true;
+    } catch (e) {}
+    await delay(100);
+  }
+  throw new Error('server did not start');
+}
+
+test.beforeAll(async () => {
+  port = 18787 + Math.floor(Math.random() * 1000);
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fc-data-'));
+  const bin = path.resolve(__dirname, '../../../target/release/family_chat');
+  proc = spawn(bin, [], {
+    env: { ...process.env, BIND: `127.0.0.1:${port}`, DATA_DIR: dataDir, RUST_LOG: 'off' },
+    stdio: 'inherit',
+  });
+
+  await waitForServer(`http://127.0.0.1:${port}/`);
+
+  await fetch(`http://127.0.0.1:${port}/api/bootstrap`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      passphrase: 'admin',
+      users: [
+        { username: 'admin', display_name: 'Admin', admin: true },
+        { username: 'user', display_name: 'User', admin: false },
+      ],
+    }),
+  });
+});
+
+test.afterAll(async () => {
+  proc.kill();
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+test('message is displayed after sending', async ({ page }) => {
+  const base = `http://127.0.0.1:${port}`;
+  await page.goto(`${base}/login`);
+  await page.fill('[data-testid="login-username"]', 'admin');
+  await page.fill('[data-testid="login-password"]', 'admin');
+  await page.click('[data-testid="login-submit"]');
+  await page.waitForSelector('[data-testid="composer-input"]');
+
+  await page.click('[data-testid="new-room-button"]');
+  const roomName = `e2e-room-${Date.now()}`;
+  await page.fill('[data-testid="new-room-name"]', roomName);
+  await page.click('[data-testid="new-room-submit"]');
+  await page.waitForSelector('[data-testid="composer-input"]');
+
+  const msg = `Hello from E2E ${Date.now()}`;
+  await page.fill('[data-testid="composer-input"]', msg);
+  await page.keyboard.press('Enter');
+
+  await expect(page.locator('[data-testid="composer-input"]')).toHaveValue('');
+  await expect(
+    page.locator('[data-testid="message-list"] [data-testid="message-text"]').last()
+  ).toHaveText(msg);
+});

--- a/plugins/family_chat/e2e/playwright.config.js
+++ b/plugins/family_chat/e2e/playwright.config.js
@@ -1,0 +1,13 @@
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: __dirname,
+  retries: 1,
+  timeout: 30000,
+  use: {
+    headless: true,
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  reporter: [['html', { outputFolder: 'playwright-report', open: 'never' }], ['line']],
+});

--- a/plugins/family_chat/package-lock.json
+++ b/plugins/family_chat/package-lock.json
@@ -1,0 +1,60 @@
+{
+  "name": "family-chat-plugin",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "family-chat-plugin",
+      "devDependencies": {
+        "playwright": "^1.41.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
+      "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
+      "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/plugins/family_chat/package.json
+++ b/plugins/family_chat/package.json
@@ -4,5 +4,8 @@
   "scripts": {
     "build": "npm --prefix webui ci && npm --prefix webui run build",
     "test": "npm --prefix webui test"
+  },
+  "devDependencies": {
+    "playwright": "^1.41.1"
   }
 }

--- a/plugins/family_chat/webui/src/components/Composer.tsx
+++ b/plugins/family_chat/webui/src/components/Composer.tsx
@@ -20,6 +20,7 @@ export default function Composer({ onSend }: Props) {
   return (
     <div className="border-t p-2">
       <textarea
+        data-testid="composer-input"
         className="w-full resize-none rounded border p-2"
         placeholder="Type a message"
         value={text}

--- a/plugins/family_chat/webui/src/components/MessageItem.tsx
+++ b/plugins/family_chat/webui/src/components/MessageItem.tsx
@@ -7,9 +7,10 @@ interface Props {
 
 export default function MessageItem({ message }: Props) {
   return (
-    <div className="px-4 py-2">
+    <div className="px-4 py-2" data-testid="message-item">
       <div className="text-sm text-gray-600">{message.user.display_name}</div>
       <div
+        data-testid="message-text"
         className="prose prose-sm"
         dangerouslySetInnerHTML={{ __html: renderMarkdown(message.text_md) }}
       />

--- a/plugins/family_chat/webui/src/components/MessageList.tsx
+++ b/plugins/family_chat/webui/src/components/MessageList.tsx
@@ -1,4 +1,6 @@
-import { FixedSizeList as List, ListOnScrollProps } from 'react-window';
+import { FixedSizeList as List } from 'react-window';
+import type { FixedSizeList } from 'react-window';
+import { useEffect, useRef } from 'react';
 import MessageItem from './MessageItem';
 import { Message } from '../lib/types';
 
@@ -8,13 +10,27 @@ interface Props {
 
 export default function MessageList({ messages }: Props) {
   const itemSize = 80;
+  const listRef = useRef<FixedSizeList>(null);
+
+  useEffect(() => {
+    listRef.current?.scrollToItem(messages.length - 1);
+  }, [messages.length]);
+
   return (
-    <List height={400} width={'100%'} itemCount={messages.length} itemSize={itemSize}>
-      {({ index, style }) => (
-        <div style={style}>
-          <MessageItem message={messages[index]} />
-        </div>
-      )}
-    </List>
+    <div data-testid="message-list">
+      <List
+        ref={listRef}
+        height={400}
+        width={'100%'}
+        itemCount={messages.length}
+        itemSize={itemSize}
+      >
+        {({ index, style }) => (
+          <div style={style}>
+            <MessageItem message={messages[index]} />
+          </div>
+        )}
+      </List>
+    </div>
   );
 }

--- a/plugins/family_chat/webui/src/components/RoomList.tsx
+++ b/plugins/family_chat/webui/src/components/RoomList.tsx
@@ -22,7 +22,7 @@ export default function RoomList() {
       setRooms((r) => [...r, room]);
       setOpen(false);
       setName('');
-      navigate(`/rooms/${room.id}`);
+      navigate(`/room/${room.id}`);
     } catch (err) {
       console.error(err);
     }
@@ -38,12 +38,17 @@ export default function RoomList() {
           </li>
         ))}
       </ul>
-      <button className="mt-2 px-2 py-1 text-sm text-blue-600" onClick={() => setOpen(true)}>
+      <button
+        data-testid="new-room-button"
+        className="mt-2 px-2 py-1 text-sm text-blue-600"
+        onClick={() => setOpen(true)}
+      >
         New Room
       </button>
       <Modal open={open} onClose={() => setOpen(false)}>
         <form onSubmit={createRoom} className="space-y-2">
           <input
+            data-testid="new-room-name"
             autoFocus
             placeholder="Room name"
             value={name}
@@ -51,7 +56,12 @@ export default function RoomList() {
             className="border p-1"
           />
           <div className="text-right">
-            <button type="submit" className="px-2 py-1 bg-blue-500 text-white rounded" disabled={!name.trim()}>
+            <button
+              type="submit"
+              data-testid="new-room-submit"
+              className="px-2 py-1 bg-blue-500 text-white rounded"
+              disabled={!name.trim()}
+            >
               Create
             </button>
           </div>

--- a/plugins/family_chat/webui/src/pages/Chat.tsx
+++ b/plugins/family_chat/webui/src/pages/Chat.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
 import Layout from '../components/Layout';
 import MessageList from '../components/MessageList';
 import Composer from '../components/Composer';
@@ -7,10 +8,13 @@ import { api } from '../lib/api';
 
 export default function Chat() {
   const [messages, setMessages] = useState<Message[]>([]);
+  const params = useParams<{ id: string }>();
+  const roomId = params.id || '1';
 
   useEffect(() => {
+    setMessages([]);
     api
-      .getMessages('1')
+      .getMessages(roomId)
       .then((msgs) => {
         setMessages((existing) => {
           const ids = new Set(existing.map((m) => m.id));
@@ -22,19 +26,19 @@ export default function Chat() {
         });
       })
       .catch(console.error);
-  }, []);
+  }, [roomId]);
 
   async function send(text: string) {
     const temp: Message = {
       id: `tmp-${Date.now()}`,
-      room_id: '1',
+      room_id: roomId,
       text_md: text,
       created_at: new Date().toISOString(),
       user: { id: 'me', username: 'me', display_name: 'Me' },
     } as Message;
     setMessages((m) => [...m, temp]);
     try {
-      const msg = await api.sendMessage({ room_id: '1', text_md: text });
+      const msg = await api.sendMessage({ room_id: roomId, text_md: text });
       setMessages((m) => m.map((x) => (x.id === temp.id ? msg : x)));
     } catch (e) {
       setMessages((m) => m.filter((x) => x.id !== temp.id));

--- a/plugins/family_chat/webui/src/pages/Login.tsx
+++ b/plugins/family_chat/webui/src/pages/Login.tsx
@@ -16,6 +16,7 @@ export default function Login() {
     <div className="p-4 max-w-sm mx-auto">
       <h1 className="mb-2 text-xl">Login</h1>
       <input
+        data-testid="login-username"
         className="mb-2 w-full rounded border p-2"
         placeholder="Username"
         value={username}
@@ -23,12 +24,17 @@ export default function Login() {
       />
       <input
         type="password"
+        data-testid="login-password"
         className="mb-2 w-full rounded border p-2"
         placeholder="Passphrase"
         value={passphrase}
         onChange={(e) => setPassphrase(e.target.value)}
       />
-      <button className="rounded bg-blue-600 px-4 py-2 text-white" onClick={submit}>
+      <button
+        data-testid="login-submit"
+        className="rounded bg-blue-600 px-4 py-2 text-white"
+        onClick={submit}
+      >
         Login
       </button>
     </div>


### PR DESCRIPTION
## Summary
- add Playwright-based E2E test that boots the family_chat plugin and verifies messages render
- expose test IDs in the UI and support dynamic rooms with auto-scroll
- run the E2E test in CI after building the UI and plugin

## Testing
- `npm --prefix plugins/family_chat/webui ci`
- `npm --prefix plugins/family_chat/webui run build`
- `npm --prefix plugins/family_chat ci`
- `cargo build -p family_chat --release`
- `npm --prefix plugins/family_chat test`
- `npx --prefix plugins/family_chat playwright install --with-deps` *(fails: Download failed: server returned code 403 body 'Domain forbidden')*
- `npx --prefix plugins/family_chat playwright test --reporter=line` *(fails: Download failed: server returned code 403 body 'Domain forbidden')*


------
https://chatgpt.com/codex/tasks/task_e_689efab6ef6483329c8c87682cb09713